### PR TITLE
Use open3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# gitgud ![gitgud badge](https://img.shields.io/badge/gitgud%3F-good-brightgreen)
+# gitgud ![gitgud badge](https://img.shields.io/badge/gitgud%3F-good-brightgreen) [![Gem Version](https://badge.fury.io/rb/gitgud.svg)](https://badge.fury.io/rb/gitgud)
 
 When things go wrong, you need to `gitgud`. `gitgud` acts just like `git`, but gives you superpowers when trying to `git push`. It will attempt to `git push` until it succeeds.
 
-![gitgud](https://user-images.githubusercontent.com/4406751/75472054-f3c92680-5960-11ea-9eaa-eff24eb4dfe4.gif)
+![success after multiple retries](https://user-images.githubusercontent.com/4406751/75736774-1c884d80-5ccc-11ea-9e2c-5436937d38ed.gif)
 
 
 ## `gitgud` is the new `git`

--- a/bin/gitgud
+++ b/bin/gitgud
@@ -1,14 +1,26 @@
 #!/usr/bin/env ruby
 
 require 'cli/ui'
+require 'open3'
 
 def try_to_push_this_thing(spinner)
   counter = 1
-  while !system('git', 'push', *ARGV)
+  while counter <= 20
     spinner.update_title(spinner_title(counter))
     counter += 1
+
+    output, status = Open3.capture2e('git', 'push', *ARGV)
+
+    if status.success?
+      return spinner.update_title("Successfully git pushed")
+    elsif !output.match?(/remote: Internal Server Error\sEverything up-to-date/)
+      spinner.update_title("Encountered error while git pushing\n#{output}")
+      return :task_failed
+    end
   end
-  spinner.update_title('Successfully git pushed')
+
+  spinner.update_title("Unsuccessful after 20 attemps")
+  :task_failed
 end
 
 def spinner_title(attempt_number = 1)
@@ -21,7 +33,7 @@ end
 
 def plz_push_my_thing_on_git_thx_k_bye
   CLI::UI::StdoutRouter.enable
-  spin_group = CLI::UI::SpinGroup.new
+  spin_group = CLI::UI::SpinGroup.new(auto_debrief: false)
   spin_group.add(spinner_title)   { |spinner| try_to_push_this_thing(spinner) }
   spin_group.wait
 end


### PR DESCRIPTION
The output of gitgud was a bit messy since git was outputting to stdout and stderr. This was fixed by using Open3. We now capture both stdout and stderr and check if the error actually is "remote: Internal Server Error Everything up-to-date" before retrying. If the command was not successful and the error isn't a match, we show the error to the user. Also, we now have a limit of 20 retries per gitgud call.

**Success after multiple retries**
![success](https://user-images.githubusercontent.com/4406751/75736774-1c884d80-5ccc-11ea-9e2c-5436937d38ed.gif)

**Failure**
![failure](https://user-images.githubusercontent.com/4406751/75736793-2611b580-5ccc-11ea-8cd0-922b5435115f.gif)

